### PR TITLE
Switch which files need validation set

### DIFF
--- a/canonical_recipes/ensemble/single_task/catboost/catboost.yaml
+++ b/canonical_recipes/ensemble/single_task/catboost/catboost.yaml
@@ -65,8 +65,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.8
-      val_size: 0.0 # For CatBoost, no validation set is needed
+      train_size: 0.7
+      val_size: 0.1 # Validation set is needed for uncertainty calibration
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration

--- a/canonical_recipes/ensemble/single_task/lgbm/lgbm.yaml
+++ b/canonical_recipes/ensemble/single_task/lgbm/lgbm.yaml
@@ -67,8 +67,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.8
-      val_size: 0.0 # For LGBM, no validation set is needed
+      train_size: 0.7
+      val_size: 0.1 # Validation set is needed for uncertainty calibration
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration

--- a/canonical_recipes/ensemble/single_task/rf/rf.yaml
+++ b/canonical_recipes/ensemble/single_task/rf/rf.yaml
@@ -66,8 +66,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.8
-      val_size: 0.0
+      train_size: 0.7
+      val_size: 0.1 # Validation set is needed for uncertainty calibration
       test_size: 0.2
 
   train:

--- a/canonical_recipes/ensemble/single_task/tabpfn/tabpfn.yaml
+++ b/canonical_recipes/ensemble/single_task/tabpfn/tabpfn.yaml
@@ -63,8 +63,9 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
+      train_size: 0.7
+      val_size: 0.1 # Validation set is needed for uncertainty calibration
       test_size: 0.2
-      train_size: 0.8
 
   # Specify training configuration
   train:

--- a/canonical_recipes/ensemble/single_task/xgboost/xgboost.yaml
+++ b/canonical_recipes/ensemble/single_task/xgboost/xgboost.yaml
@@ -67,8 +67,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.8
-      val_size: 0.0 # For LGBM, no validation set is needed
+      train_size: 0.7
+      val_size: 0.1 # Validation set is needed for uncertainty calibration
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration

--- a/canonical_recipes/single_task/catboost/catboost.yaml
+++ b/canonical_recipes/single_task/catboost/catboost.yaml
@@ -59,8 +59,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.7
-      val_size: 0.1 # For ensemble models, validation is used for calibration
+      train_size: 0.8
+      val_size: 0.0 # No validation set is needed
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration

--- a/canonical_recipes/single_task/lgbm/lgbm.yaml
+++ b/canonical_recipes/single_task/lgbm/lgbm.yaml
@@ -62,8 +62,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.7
-      val_size: 0.1 # For ensemble models, validation is used for calibration
+      train_size: 0.8
+      val_size: 0.0 # No validation set is needed
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration

--- a/canonical_recipes/single_task/rf/rf.yaml
+++ b/canonical_recipes/single_task/rf/rf.yaml
@@ -60,8 +60,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.7
-      val_size: 0.1 # For ensemble models, validation is used for calibration
+      train_size: 0.8
+      val_size: 0.0 # No validation set is needed
       test_size: 0.2
 
   train:

--- a/canonical_recipes/single_task/tabpfn/tabpfn.yaml
+++ b/canonical_recipes/single_task/tabpfn/tabpfn.yaml
@@ -54,8 +54,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.7
-      val_size: 0.1 # For ensemble models, validation is used for calibration
+      train_size: 0.8
+      val_size: 0.0 # No validation set is needed
       test_size: 0.2
     # Specify how data will be split, can be ShuffleSplitter, ScaffoldSplitter, etc.
     # See openadmet.models.split

--- a/canonical_recipes/single_task/xgboost/xgboost.yaml
+++ b/canonical_recipes/single_task/xgboost/xgboost.yaml
@@ -61,8 +61,8 @@ procedure:
     # Specify split parameters
     params:
       random_state: 42
-      train_size: 0.7
-      val_size: 0.1 # For ensemble models, validation is used for calibration
+      train_size: 0.8
+      val_size: 0.0 # No validation set is needed
       test_size: 0.2 # If you want to compare tree-based models with Dl models later, the test sizes should match
     
   # Specify training configuration


### PR DESCRIPTION
Accidentally kept the ensemble configs unchanged, and changed the non-ensemble classic-ML methods to have a validation set. This switches them to be as expected.