### PR TITLE
Add default parameters to featurizer

### DIFF
--- a/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
@@ -42,8 +42,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
@@ -42,8 +42,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
@@ -33,8 +33,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
@@ -33,8 +33,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/ensemble/single_task/gat/gat.yaml
+++ b/canonical_recipes/ensemble/single_task/gat/gat.yaml
@@ -47,8 +47,10 @@ procedure:
     # Using the GATGraphFeaturizer (for GAT model)
     # See openadmet.models.features
     type: "GATGraphFeaturizer"
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      shuffle: True
+      num_workers: 4
 
   # Model specification
   model:

--- a/canonical_recipes/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/multitask/chemeleon/chemeleon.yaml
@@ -42,8 +42,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/multitask/chemprop/chemprop.yaml
@@ -42,8 +42,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/single_task/chemeleon/chemeleon.yaml
@@ -33,8 +33,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/single_task/chemprop/chemprop.yaml
@@ -33,8 +33,11 @@ procedure:
     # Using the ChemPropFeaturizer (for ChemProp model)
     # See openadmet.models.features
     type: ChemPropFeaturizer
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      normalize_targets: true
+      shuffle: true
+      n_jobs: 4
   
   # Model specification
   model:

--- a/canonical_recipes/single_task/gat/gat.yaml
+++ b/canonical_recipes/single_task/gat/gat.yaml
@@ -47,8 +47,10 @@ procedure:
     # Using the GATGraphFeaturizer (for GAT model)
     # See openadmet.models.features
     type: "GATGraphFeaturizer"
-    # No parameters passed
-    params: {}
+    params:
+      batch_size: 128
+      shuffle: True
+      num_workers: 4
 
   # Model specification
   model:


### PR DESCRIPTION
Not super clear where to configure e.g. `batch_size` in anvil workflows, so thought we'd add to canonical recipes explicitly to alleviate learning curve some. For e.g. ChemProp, adds:

```yaml
batch_size: 128
normalize_targets: true
shuffle: true
n_jobs: 4
```