### PR TITLE
Remove `shuffle` from config to obfuscate until fixed

### DIFF
--- a/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
@@ -45,7 +45,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
@@ -45,7 +45,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
@@ -36,7 +36,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
@@ -36,7 +36,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/ensemble/single_task/gat/gat.yaml
+++ b/canonical_recipes/ensemble/single_task/gat/gat.yaml
@@ -49,7 +49,6 @@ procedure:
     type: "GATGraphFeaturizer"
     params:
       batch_size: 128
-      shuffle: True
       num_workers: 4
 
   # Model specification

--- a/canonical_recipes/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/multitask/chemeleon/chemeleon.yaml
@@ -45,7 +45,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/multitask/chemprop/chemprop.yaml
@@ -45,7 +45,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/single_task/chemeleon/chemeleon.yaml
@@ -36,7 +36,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/single_task/chemprop/chemprop.yaml
@@ -36,7 +36,6 @@ procedure:
     params:
       batch_size: 128
       normalize_targets: true
-      shuffle: true
       n_jobs: 4
   
   # Model specification

--- a/canonical_recipes/single_task/gat/gat.yaml
+++ b/canonical_recipes/single_task/gat/gat.yaml
@@ -49,7 +49,6 @@ procedure:
     type: "GATGraphFeaturizer"
     params:
       batch_size: 128
-      shuffle: True
       num_workers: 4
 
   # Model specification


### PR DESCRIPTION
We shouldn't be shuffling until `openadmet-models` [issue #383](https://github.com/OpenADMET/openadmet-models/issues/383) is addressed.