### PR TITLE
Update chemeleon and chemprop default hyperparameters

### DIFF
--- a/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml
@@ -54,13 +54,13 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      mpnn_lr: 1e-4
+      mpnn_lr: 1e-3
       ffn_lr: 1e-3
       mpnn_weight_decay: 0
       ffn_weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: plateau
       reduce_lr_patience: 5
@@ -72,7 +72,7 @@ procedure:
   ensemble:
     type: CommitteeRegressor
     n_models: 5
-    use_bagging: True
+    use_bagging: False
     calibration_method: scaling-factor
     plot_errbars: True
 

--- a/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml
@@ -54,11 +54,11 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      max_lr: 1e-3
+      mpnn_lr: 1e-3
       weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: noam
       warmup_epochss: 2
@@ -69,7 +69,7 @@ procedure:
   ensemble:
     type: CommitteeRegressor
     n_models: 5
-    use_bagging: True
+    use_bagging: False
     calibration_method: scaling-factor
     plot_errbars: True
 

--- a/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml
@@ -45,13 +45,13 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      mpnn_lr: 1e-4
+      mpnn_lr: 1e-3
       ffn_lr: 1e-3
       mpnn_weight_decay: 0
       ffn_weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: plateau
       reduce_lr_patience: 5
@@ -63,7 +63,7 @@ procedure:
   ensemble:
     type: CommitteeRegressor
     n_models: 5
-    use_bagging: True
+    use_bagging: False
     calibration_method: scaling-factor
     plot_errbars: True
 

--- a/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml
@@ -45,11 +45,11 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      max_lr: 1e-3
+      mpnn_lr: 1e-3
       weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: noam
       warmup_epochss: 2
@@ -60,7 +60,7 @@ procedure:
   ensemble:
     type: CommitteeRegressor
     n_models: 5
-    use_bagging: True
+    use_bagging: False
     calibration_method: scaling-factor
     plot_errbars: True
 

--- a/canonical_recipes/multitask/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/multitask/chemeleon/chemeleon.yaml
@@ -54,13 +54,13 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      mpnn_lr: 1e-4
+      mpnn_lr: 1e-3
       ffn_lr: 1e-3
       mpnn_weight_decay: 0
       ffn_weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: plateau
       reduce_lr_patience: 5

--- a/canonical_recipes/multitask/chemprop/chemprop.yaml
+++ b/canonical_recipes/multitask/chemprop/chemprop.yaml
@@ -54,11 +54,11 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      max_lr: 1e-3
+      mpnn_lr: 1e-3
       weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: noam
       warmup_epochss: 2

--- a/canonical_recipes/single_task/chemeleon/chemeleon.yaml
+++ b/canonical_recipes/single_task/chemeleon/chemeleon.yaml
@@ -45,13 +45,13 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      mpnn_lr: 1e-4
+      mpnn_lr: 1e-3
       ffn_lr: 1e-3
       mpnn_weight_decay: 0
       ffn_weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: plateau
       reduce_lr_patience: 5

--- a/canonical_recipes/single_task/chemprop/chemprop.yaml
+++ b/canonical_recipes/single_task/chemprop/chemprop.yaml
@@ -45,11 +45,11 @@ procedure:
     type: ChemPropModel
     # Specify model parameters
     params:
-      ffn_hidden_dim: 512
+      ffn_hidden_dim: 1024
       ffn_hidden_num_layers: 3
-      max_lr: 1e-3
+      mpnn_lr: 1e-3
       weight_decay: 1e-4
-      dropout: 0.25
+      dropout: 0.1
       batch_norm: False
       scheduler: noam
       warmup_epochss: 2


### PR DESCRIPTION
Updates default model parameters across all canonical recipes (single-task, multitask, and ensemble) for both chemeleon and chemprop.

**Changes**
- `ffn_hidden_dim`: 512 → 1024
- `dropout`: 0.25 → 0.1
- `mpnn_lr`: 1e-4 → 1e-3 (chemeleon); `max_lr` renamed to `mpnn_lr` in chemprop files (value was already 1e-3)
- `use_bagging`: `True` → `False` (ensemble recipes only)
- `ffn_num_layers`: already 3 everywhere, no change

**Files affected**
- `canonical_recipes/single_task/chemeleon/chemeleon.yaml`
- `canonical_recipes/single_task/chemprop/chemprop.yaml`
- `canonical_recipes/multitask/chemeleon/chemeleon.yaml`
- `canonical_recipes/multitask/chemprop/chemprop.yaml`
- `canonical_recipes/ensemble/single_task/chemeleon/chemeleon.yaml`
- `canonical_recipes/ensemble/single_task/chemprop/chemprop.yaml`
- `canonical_recipes/ensemble/multitask/chemeleon/chemeleon.yaml`
- `canonical_recipes/ensemble/multitask/chemprop/chemprop.yaml`